### PR TITLE
Story rio gebieden

### DIFF
--- a/stories/rioleringsgebieden/buurten-in-rioleringsgebied.rq
+++ b/stories/rioleringsgebieden/buurten-in-rioleringsgebied.rq
@@ -16,17 +16,20 @@ PREFIX cbs_83487: <http://betalinkeddata.cbs.nl/def/83487NED#>
 SELECT ?wkt ?wktLabel ?wktColor WHERE {
   {
     SERVICE <https://sparql.gwsw.nl/repositories/TestDatastory> {
-      ?rg a gwsw:Rioleringsgebied ;
-          rdfs:label ?wktLabel ;
-          gwsw:hasAspect ?ori .
-      ?ori a gwsw:Gebiedsorientatie ;
-           gwsw:hasAspect ?bg .
-      ?bg a gwsw:Buitengrens ;
-          geo:asWKT ?wkt .
-      filter(contains(?wktLabel, "Castricum"))
-      bind("green" as ?wktColor)
+	
+	  ?rg a gwsw:Rioleringsgebied ;
+		  rdfs:label ?rg_naam ;
+		  gwsw:hasAspect ?ori .
+	  ?ori a gwsw:Gebiedsorientatie ;
+		   gwsw:hasAspect ?bg .
+	  ?bg a gwsw:Buitengrens ;
+		  geo:asWKT ?wkt .
+	  filter(contains(?wktLabel, "Castricum"))
+	  bind (concat("<h3><a target='_blank' href='https://sparql.gwsw.nl/resource?uri=", str(?rg), "'>", str(?rg_naam), "</a></h3>") as ?wktLabel)
+	  bind("green" as ?wktColor)
     }
-  } UNION {
+  } 
+  UNION {
     SERVICE <https://sparql.gwsw.nl/repositories/TestDatastory> {
       ?rg a gwsw:Rioleringsgebied ;
           rdfs:label ?wktlabel ;
@@ -35,10 +38,11 @@ SELECT ?wkt ?wktLabel ?wktColor WHERE {
            gwsw:hasAspect ?bg .
       ?bg a gwsw:Buitengrens ;
           geo:asWKT ?wkt_gwsw .
-      filter(contains(?wktlabel, "Castricum"))
+      #filter(contains(?wktlabel, "Castricum"))
     }
-
     ?cbs_gemeente rdfs:label "Castricum"@nl .
+    ?cbs_gemeente rdfs:label ?gemeente_naam .
+
     ?buurt a cbs:Buurt;
       rdfs:label ?buurt_label ;
          geo:hasGeometry ?geom ;
@@ -46,8 +50,12 @@ SELECT ?wkt ?wktLabel ?wktColor WHERE {
       ?geom geo:asWKT ?wkt .
     ?wijk a cbs:Wijk;
           ?within ?cbs_gemeente .
-    ?geom geo:asWKT ?wkt_cbsgem .
-    filter(geof:sfIntersects(?wkt_cbsgem, ?wkt_gwsw))
+		  
+    ?wijk rdfs:label ?wijk_naam .
+	filter(geof:sfIntersects(?wkt, ?wkt_gwsw))
+     
+    #?geom geo:asWKT ?wkt_cbsgem .
+    #filter(geof:sfIntersects(?wkt_cbsgem, ?wkt_gwsw))
 
     # Veelzeggende eigenschappen van de buurt
     ?aantal_inwoners_obs cbs_dim:regio ?buurt ;
@@ -61,16 +69,22 @@ SELECT ?wkt ?wktLabel ?wktColor WHERE {
 	  optional {
 		?bedrijven cbs_dim:regio ?buurt ;
 				   cbs_qb:inObservationGroup cbs_slice:bedrijfsvestigingen_Sbi2008_BedrijfsvestigingenTotaal ;
-				   cbs_83487:bedrijfsvestigingen_Sbi2008_BedrijfsvestigingenTotaal ?bedrijven_aantal .
+				   cbs_83487:bedrijfsvestigingen_Sbi2008_BedrijfsvestigingenTotaal ?aantal_bedrijven .
 		?recreatie cbs_dim:regio ?buurt ;
 				   cbs_qb:inObservationGroup cbs_slice:bedrijfsvestigingen_Sbi2008_BedrijfsvestigingenNaarActiviteit_R-uCultuur_Recreatie_OverigeDiensten ;
-				   cbs_83487:bedrijfsvestigingen_Sbi2008_BedrijfsvestigingenNaarActiviteit_R-uCultuur_Recreatie_OverigeDiensten ?recreatie_aantal .
+				   cbs_83487:bedrijfsvestigingen_Sbi2008_BedrijfsvestigingenNaarActiviteit_R-uCultuur_Recreatie_OverigeDiensten ?aantal_recreatie .
 	  }
 
     bind(concat(
         "<a href='", str(?buurt), "' target='_blank'><h2>", str(?buurt_label), "</h2></a>",
-        "<p>Aantal inwoners: <a target='_blank' href='", str(?aantal_inwoners_obs), "'>", str(?aantal_inwoners), "</a></p>",
-        "<p>Aantal huishoudens:  <a target='_blank' href='", str(?aantal_huishoudens_obs), "'>", str(?aantal_huishoudens), "</p>"
+        "<p>Gemeentenaam: <a target='_blank' href='", str(?cbs_gemeente), "'>", str(?gemeente_naam), "</a></p>",
+        "<p>Wijknaam: <a target='_blank' href='", str(?wijk), "'>", str(?wijk_naam), "</a></p>",
+         "<p>Aantal inwoners: <a target='_blank' href='", str(?aantal_inwoners_obs), "'>", str(?aantal_inwoners), "</a></p>",
+         "<p>Aantal huishoudens:  <a target='_blank' href='", str(?aantal_huishoudens_obs), "'>", str(?aantal_huishoudens), "</a></p>",
+         "<p>Aantal bedrijven:  <a target='_blank' href='", str(?bedrijven), "'>", str(?aantal_bedrijven), "</a></p>", 
+        "<p>- waarvan recreatie:  <a target='_blank' href='", str(?recreatie), "'>", str(?aantal_recreatie), "</a></p>"
       ) as ?wktLabel)
+	  
+    bind("purple" as ?wktColor)
   }
 }

--- a/stories/rioleringsgebieden/index.md
+++ b/stories/rioleringsgebieden/index.md
@@ -12,7 +12,7 @@ logo: /stories/rioleringsgebieden/logo.jpg
 Gemeenten en waterschappen maken gebruik van veel verschillende informatiebronnen bij de inzameling, het transport en de zuivering van afvalwater. Is het mogelijk om deze bronnen met behulp van Linked Data en SPARQL 'on the fly' bijeen te garen? Dat zou een flinke verbetering zijn ten opzichte van de huidige werkwijze, waarbij handmatig gegevensbronnen van verschillende partijen gecombineerd worden. Deze data story verkent de mogelijkheden om 'federatief' vanuit verschillende bronnen informatie te vergaren rondom het thema afvalwaterketen.
 
 ## Rioleringsgebied Castricum 
-De datasets gebaseerd op het Gegevenswoordenboek Stedelijk Water [GWSW](https://apps.gwsw.nl) bevatten informatie rondom het thema transport en zuivering.
+De datasets gebaseerd op het Gegevenswoordenboek Stedelijk Water [GWSW](https://data.gwsw.nl) bevatten informatie rondom het thema transport en zuivering.
 Een zuiveringsgebied omvat een rioolwaterzuiveringsinstallatie (RWZI) en een aantal rioleringsgebieden die afwateren naar die RWZI. Vaak zit hier een gemaal bij om het transport een handje te helpen. 
 
 We bekijken hier het rioleringsgebied van Castricum. We vragen dit gebied op met de bijbehorende uitlaten en pompen uit het toegangspunt van het GWSW. Hieronder wordt een selectie van de beschikbare gegevens getoond.
@@ -80,7 +80,7 @@ Door genoemde data met elkaar te combineren kunnen we een rapport genereren met 
 Stichting RIONED onderhoudt en ontwikkelt GWSW Geo, dat zijn GIS-toepassingen op het GWSW. Daarmee worden de datasets van gemeentes volgens meerdere thema's (per doelgroep) geografisch gepresenteerd. 
 Deze datastory vormt de inspiratiebron voor het GWSW Geo-thema "Kengetallen", waarin de "federatieve" query-vorm verder wordt ontwikkeld.
 
-De GIS presentatie van de hier gebruikte GWSW-dataset staat op daarvan staat op [https://qgiscloud.com/RIONED/TestDatastory](https://qgiscloud.com/RIONED/TestDatastory).
+De GIS presentatie van de hier gebruikte GWSW-dataset staat op daarvan staat op [https://qgiscloud.com/RIONED/Datastory](https://qgiscloud.com/RIONED/Datastory).
 GIS gebruikers kunnen de GWSW vorm van deze testcase conform WFS opvragen op: [https://geodata.gwsw.nl/TestDatastory/kengetallen](https://geodata.gwsw.nl/TestDatastory/kengetallen)
 
 <!-- div data-query

--- a/stories/rioleringsgebieden/index.md
+++ b/stories/rioleringsgebieden/index.md
@@ -12,17 +12,19 @@ logo: /stories/rioleringsgebieden/logo.jpg
 Gemeenten en waterschappen maken gebruik van veel verschillende informatiebronnen bij de inzameling, het transport en de zuivering van afvalwater. Is het mogelijk om deze bronnen met behulp van Linked Data en SPARQL 'on the fly' bijeen te garen? Dat zou een flinke verbetering zijn ten opzichte van de huidige werkwijze, waarbij handmatig gegevensbronnen van verschillende partijen gecombineerd worden. Deze data story verkent de mogelijkheden om 'federatief' vanuit verschillende bronnen informatie te vergaren rondom het thema afvalwaterketen.
 
 ## Rioleringsgebied Castricum 
-De datasets gebaseerd op het Gegevenswoordenboek Stedelijk Water [GWSW](https://apps.gwsw.nl) bevatten informatie rondom het thema transport en zuivering. Een zuiveringsgebied omvat een rioolwaterzuiveringsinstallatie (RWZI) en een aantal rioleringsgebieden die afwateren naar die RWZI. Vaak zit hier een gemaal bij om het transport een handje te helpen. 
+De datasets gebaseerd op het Gegevenswoordenboek Stedelijk Water [GWSW](https://apps.gwsw.nl) bevatten informatie rondom het thema transport en zuivering.
+Een zuiveringsgebied omvat een rioolwaterzuiveringsinstallatie (RWZI) en een aantal rioleringsgebieden die afwateren naar die RWZI. Vaak zit hier een gemaal bij om het transport een handje te helpen. 
 
-We bekijken hier het rioleringsgebied van Castricum. We vragen dit gebied op uit het toegangspunt van het GWSW. Hieronder wordt een selectie van de beschikbare gegevens getoond.
+We bekijken hier het rioleringsgebied van Castricum. We vragen dit gebied op met de bijbehorende uitlaten en pompen uit het toegangspunt van het GWSW. Hieronder wordt een selectie van de beschikbare gegevens getoond.
 
 <div data-query
      data-query-endpoint="https://data.pdok.nl/sparql"
      data-query-sparql="rioleringsgebied.rq">
 </div>
 
-## BRT zuiveringsinstallaties in regio
-De Basisregistratie Topografie [BRT](https://brt.basisregistraties.overheid.nl), die door het Kadaster ontsloten wordt, biedt informatie omtrent de RWZI's. Het rioleringsgebied Castricum kent zelf geen waterzuiveringsinstallaties, we kennen de geometrie van het zuiveringsgebied niet, maar we kunnen wel de dichtstbijzijnde opvragen. Zo ook voor deze locatie, de directe omgeving van het zuiveringsgebied kent twee zuiveringsinstallaties in de BRT:
+## Zuiveringsinstallaties in de regio
+De Basisregistratie Topografie [BRT](https://brt.basisregistraties.overheid.nl), die door het Kadaster ontsloten wordt, biedt informatie omtrent de RWZI's. Het rioleringsgebied Castricum kent zelf geen waterzuiveringsinstallaties, we kennen de geometrie van het zuiveringsgebied niet, maar we kunnen wel de dichtstbijzijnde opvragen. 
+Zo ook voor deze locatie, de directe omgeving van het zuiveringsgebied kent twee zuiveringsinstallaties in de BRT:
 
 <div data-query
      data-query-endpoint="https://data.pdok.nl/sparql"
@@ -30,13 +32,17 @@ De Basisregistratie Topografie [BRT](https://brt.basisregistraties.overheid.nl),
 </div>
 
 ## Gemeentes rond het rioleringsgebied
-We kunnen snel aan de slag om informatie uit andere bronnen te benutten. De waterschappen zijn niet gebonden aan gemeentegrenzen, dus in welke gemeente(s) ligt het rioleringsgebied Castricum eigenlijk? Aangezien de toegang tot gemeentenamen worden geleverd via de Basisregistratie Topografie (BRT), vragen we met een ruimtelijke query de bijbehorende gemeentes op. Als je goed inzoomt, blijkt dat er naast Castricum een kleine overlap is met de gemeentes Bergen, Heemskerk en Uitgeest:
+We kunnen snel aan de slag om informatie uit andere bronnen te benutten. De waterschappen zijn niet gebonden aan gemeentegrenzen, dus in welke gemeente(s) ligt het rioleringsgebied Castricum eigenlijk? 
+Aangezien de toegang tot gemeentenamen worden geleverd via de Basisregistratie Topografie (BRT), vragen we met een ruimtelijke query de bijbehorende gemeentes op. 
+Als je goed inzoomt, blijkt dat er naast Castricum een kleine overlap is met de gemeentes Bergen, Heemskerk en Uitgeest:
 
 <div data-query
      data-query-endpoint="https://data.pdok.nl/sparql"
      data-query-sparql="gemeentes-bij-regio.rq">
 </div>
 
+
+<!-- Woonplaatsen en panden voegen niet zo veel toe, de BRT-connectie is aangetoond met de vorige query
 ## Woonplaatsen rond het rioleringsgebied
 Gewapend met de kennis over de gemeentes rond het rioleringsgebied kunnen we nu de bijbehorende plaatsnamen opvragen. Dit doen we door een kleine buffer (in oranje) om de gemeente te leggen en alleen die woonplaatsgebieden te selecteren die hier volledig binnen vallen. Het gaat om enkel Castricum, wat Bakkum (volgens de BAG) omvat:
 
@@ -52,10 +58,16 @@ Vanuit de Basisregistraties Adressen en Gebouwen (BAG) zouden we nu kunnen opvra
      data-query-endpoint="https://data.pdok.nl/sparql"
      data-query-sparql="panden-in-rioleringsgebied.rq">
 </div>
+-->
 
+## Afvoer binnen het rioleringsgebied 
+Voor het beheer en de (capaciteits)ontwikkeling van de rioolstelsels, de rioolgemalen en de RWZI is het van belang te weten wat de wijzigingen zijn in grondgebruik en inwoneraantallen.
+Elke gegevensbron (BAG, BGT, GWSW) kan afzonderlijk worden bijgehouden zonder duplicatie en op verzoek worden gecombineerd. Die combinatie van gegevens wordt in het vakgebied de "kengetallen" van het rioleringsgebied genoemd. 
+Met de Basisregistraties Adressen en Gebouwen (BAG) kunnen we de panden binnen het rioleringsgebied opvragen. Het gaat ons echter om de afvoer binnen de afvalwaterketen, de belasting van de RWZI. Die gegevens over bedrijven en inwoners vinden we bij het CBS.
 
-## Statistieken voor buurten in het rioleringsgebied: 
-Voor het beheer en de (capaciteits)ontwikkeling van de rioolstelsels, de rioolgemalen en de RWZI is het van belang te weten wat de wijzigingen zijn in grondgebruik en inwoneraantallen. Die gegevens vinden we bij het CBS. Het CBS verzamelt per buurt vele statistieken, waaronder gegevens over het landgebruik en het aantal mensen dat er woont.
+**CBS Statistieken**  
+De combinatie is met behulp van locatiegegevens gevonden: het zijn de buurten die binnen het rioleringsgebied vallen en die daarmee afwateren via rioolstelsels naar de RWZI. 
+Het CBS verzamelt per buurt vele statistieken, waaronder gegevens over het landgebruik en het aantal mensen dat er woont. We vragen bij het CBS de buurten op die het rioleringsgebied overlappen:
 
 <div data-query
      data-query-endpoint="https://betalinkeddata.cbs.nl/sparql"
@@ -63,15 +75,18 @@ Voor het beheer en de (capaciteits)ontwikkeling van de rioolstelsels, de rioolge
 </div>
 
 
-## Combineren van data met kengetallen in het GWSW
-Door genoemde data met elkaar te combineren kunnen we een rapport genereren met informatie uit verschillende bronnen. Elke gegevensbron kan afzonderlijk worden bijgehouden zonder duplicatie en op verzoek worden gecombineerd. De combinatie wordt met behulp van locatiegegevens gevonden: het zijn de buurten die binnen de rioleringsgebieden vallen en die daarmee afwateren via rioolstelsels naar de RWZI. Die combinatie van gegevens wordt in het vakgebied de "kengetallen" van het rioleringsgebied genoemd.
+## Combineren van data naar kengetallen met het GWSW
+Door genoemde data met elkaar te combineren kunnen we een rapport genereren met informatie uit verschillende bronnen. 
+Stichting RIONED onderhoudt en ontwikkelt GWSW Geo, dat zijn GIS-toepassingen op het GWSW. Daarmee worden de datasets van gemeentes volgens meerdere thema's (per doelgroep) geografisch gepresenteerd. 
+Deze datastory vormt de inspiratiebron voor het GWSW Geo-thema "Kengetallen", waarin de "federatieve" query-vorm verder wordt ontwikkeld.
 
-Stichting RIONED ontwikkelt GWSW Geo, dat zijn GIS-toepassingen op het GWSW. Daarmee worden de datasets van gemeentes volgens meerdere thema's (per doelgroep) geografisch gepresenteerd. Deze datastory vormt de inspiratiebron voor het GWSW Geo-thema "Kengetallen", waarin de "federatieve" query-vorm verder wordt ontwikkeld. GIS gebruikers kunnen de GWSW vorm van deze testcase conform WFS opvragen op: [https://geodata.gwsw.nl/TestDatastory/kengetallen](https://geodata.gwsw.nl/TestDatastory/kengetallen)
+De GIS presentatie van de hier gebruikte GWSW-dataset staat op daarvan staat op [https://qgiscloud.com/RIONED/TestDatastory](https://qgiscloud.com/RIONED/TestDatastory).
+GIS gebruikers kunnen de GWSW vorm van deze testcase conform WFS opvragen op: [https://geodata.gwsw.nl/TestDatastory/kengetallen](https://geodata.gwsw.nl/TestDatastory/kengetallen)
 
-<div data-query
+<!-- div data-query
      data-query-endpoint="https://sparql.gwsw.nl/repositories/TestDatastory"
      data-query-sparql="kengetallen.rq">
-</div>
+</div -->
 
 
 

--- a/stories/rioleringsgebieden/index.md
+++ b/stories/rioleringsgebieden/index.md
@@ -1,15 +1,15 @@
 ---
 layout: story
-title: Gegevensbronnen combineren voor waterzuivering en riolering
+title: Combineren van gegevensbronnen in de afvalwaterketen
 published: true
 endpoint: https://data.pdok.nl/sparql
 output: leaflet
 logo: /stories/rioleringsgebieden/logo.jpg
 ---
 
-# Combineren van gegevensbronnen voor waterzuivering en riolering
+# Combineren van gegevensbronnen in de afvalwaterketen
 
-Waterschappen en gemeenten maken gebruik van veel verschillende informatiebronnen bij de inzameling, het transport en de zuivering van afvalwater. Is het mogelijk om deze bronnen met behulp van Linked Data en SPARQL 'on the fly' bijeen te garen? Dat zou een flinke verbetering zijn ten opzichte van de huidige werkwijze, waarbij handmatig gegevensbronnen van verschillende partijen gecombineerd worden. Deze data story verkent de mogelijkheden om 'federatief' vanuit verschillende bronnen informatie te vergaren rondom het thema afvalwaterketen.
+Gemeenten en waterschappen maken gebruik van veel verschillende informatiebronnen bij de inzameling, het transport en de zuivering van afvalwater. Is het mogelijk om deze bronnen met behulp van Linked Data en SPARQL 'on the fly' bijeen te garen? Dat zou een flinke verbetering zijn ten opzichte van de huidige werkwijze, waarbij handmatig gegevensbronnen van verschillende partijen gecombineerd worden. Deze data story verkent de mogelijkheden om 'federatief' vanuit verschillende bronnen informatie te vergaren rondom het thema afvalwaterketen.
 
 ## Rioleringsgebied Castricum 
 De datasets gebaseerd op het Gegevenswoordenboek Stedelijk Water [GWSW](https://apps.gwsw.nl) bevatten informatie rondom het thema transport en zuivering. Een zuiveringsgebied omvat een rioolwaterzuiveringsinstallatie (RWZI) en een aantal rioleringsgebieden die afwateren naar die RWZI. Vaak zit hier een gemaal bij om het transport een handje te helpen. 
@@ -68,10 +68,10 @@ Door genoemde data met elkaar te combineren kunnen we een rapport genereren met 
 
 Stichting RIONED ontwikkelt GWSW Geo, dat zijn GIS-toepassingen op het GWSW. Daarmee worden de datasets van gemeentes volgens meerdere thema's (per doelgroep) geografisch gepresenteerd. Deze datastory vormt de inspiratiebron voor het GWSW Geo-thema "Kengetallen", waarin de "federatieve" query-vorm verder wordt ontwikkeld. GIS gebruikers kunnen de GWSW vorm van deze testcase conform WFS opvragen op: [https://geodata.gwsw.nl/TestDatastory/kengetallen](https://geodata.gwsw.nl/TestDatastory/kengetallen)
 
-<!-- div data-query
+<div data-query
      data-query-endpoint="https://sparql.gwsw.nl/repositories/TestDatastory"
      data-query-sparql="kengetallen.rq">
-</div -->
+</div>
 
 
 

--- a/stories/rioleringsgebieden/rioleringsgebied.rq
+++ b/stories/rioleringsgebieden/rioleringsgebied.rq
@@ -5,33 +5,103 @@ PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
 PREFIX brt: <http://brt.basisregistraties.overheid.nl/def/top10nl#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX sesame: <http://www.openrdf.org/schema/sesame#>
 
-SELECT ?wktLabel ?wkt ?wktColor WHERE {
-  SERVICE <https://sparql.gwsw.nl/repositories/TestDatastory> {
-    SELECT
-    ?rg ?wkt
-    (concat("<h3><a target='_blank' href='", str(?rg), "'>", str(?label), "</a></h3><br>Totale leidinglengte: ", str(sum(?lengte))) AS ?wktLabel)
-    WHERE {
-      ?rg a gwsw:Rioleringsgebied ;
-          rdfs:label ?label ;
-          gwsw:hasAspect ?ori .
-      ?ori a gwsw:Gebiedsorientatie ;
-           gwsw:hasAspect ?bg .
-      ?bg a gwsw:Buitengrens ;
-          geo:asWKT ?wkt .
-      filter(contains(?label, "Castricum"))
+SELECT ?wkt ?wktLabel ?wktColor 
+WHERE {
+	{
+	  SERVICE <https://sparql.gwsw.nl/repositories/TestDatastory> {
+		SELECT ?wkt (concat("<h3><a target='_blank' href='https://sparql.gwsw.nl/resource?uri=", str(?rg), "'>", str(?label), "</a></h3><br>Totale leidinglengte: ", str(sum(?lengte))) AS ?wktLabel)
+		WHERE {
+		  ?rg a gwsw:Rioleringsgebied ;
+			  rdfs:label ?label ;
+			  gwsw:hasAspect ?ori .
+		  ?ori a gwsw:Gebiedsorientatie ;
+			   gwsw:hasAspect ?bg .
+		  ?bg a gwsw:Buitengrens ;
+			  geo:asWKT ?wkt .
+		  filter(contains(?label, "Castricum"))
 
-      ?rg gwsw:hasPart ?rs .
-      ?rs rdfs:label ?rs_naam ;
-          gwsw:hasPart ?lei .
-      ?lei a gwsw:Leiding .
+		  ?rg gwsw:hasPart ?rs .
+		  ?rs gwsw:hasPart ?lei .
+		  ?lei a gwsw:Leiding .
 
-      ?lei gwsw:hasAspect [
-          a gwsw:LengteLeiding ;
-          gwsw:hasValue ?lengte ;
-          ] .
-    }
-    GROUP BY ?rg ?wkt ?label
-  }
-  bind("green" as ?wktColor)
+		  ?lei gwsw:hasAspect [
+			  a gwsw:LengteLeiding ;
+			  gwsw:hasValue ?lengte ;
+			  ] .
+		}
+		GROUP BY ?rg ?wkt ?label
+	  }
+	  bind("green" as ?wktColor)
+	}
+	UNION
+	{ 
+	  SERVICE <https://sparql.gwsw.nl/repositories/TestDatastory> {
+		SELECT ?wkt (concat("<h3><a target='_blank' href='https://sparql.gwsw.nl/resource?uri=", str(?put), "'>", str(?naam), "</a></h3><br>Stelsel: ", str(?rs_naam), "<br>Type uitlaat: <a target='_blank' href='" , str(?type), "'>", str(?type), "</a>") AS ?wktLabel)
+		WHERE {
+		  ?rg a gwsw:Rioleringsgebied ;
+   			  rdfs:label ?label ;
+		  filter(contains(?label, "Castricum"))
+		  ?rg gwsw:hasPart ?rs .
+		  ?rs rdfs:label ?rs_naam ;
+			  gwsw:hasPart ?put .
+		  
+		   ?put a gwsw:Overstortput .
+  	       ?put sesame:directType ?type .
+           FILTER (!(isBlank(?put)))
+           FILTER (!(isBlank(?type)))
+			
+		   ?put rdfs:label ?naam .
+
+		   ?put gwsw:hasAspect 
+			[
+				rdf:type gwsw:Putorientatie ;
+
+				gwsw:hasAspect
+				[ 
+					rdf:type gwsw:Punt ;
+					geo:asWKT ?wkt ;
+				] ;
+			] .
+		}
+	  }
+	  bind("blue" as ?wktColor)
+	}
+	UNION
+	{ 
+	  SERVICE <https://sparql.gwsw.nl/repositories/TestDatastory> {
+		SELECT ?wkt (concat("<h3><a target='_blank' href='https://sparql.gwsw.nl/resource?uri=", str(?put), "'>", str(?naam), "</a></h3><br>Stelsel: ", str(?rs_naam), "<br>Type pomp: <a target='_blank' href='" , str(?type), "'>", str(?type), "</a>") AS ?wktLabel)
+		WHERE {
+		  ?rg a gwsw:Rioleringsgebied ;
+   			  rdfs:label ?label ;
+		  filter(contains(?label, "Castricum"))
+		  ?rg gwsw:hasPart ?rs .
+		  ?rs rdfs:label ?rs_naam ;
+			  gwsw:hasPart ?put .
+		  
+		   ?put a gwsw:Pompput .
+  	       ?put sesame:directType ?type .
+           FILTER (!(isBlank(?put)))
+           FILTER (!(isBlank(?type)))
+
+		   ?put sesame:directType ?type .
+			
+		   ?put rdfs:label ?naam .
+
+		   ?put gwsw:hasAspect 
+			[
+				rdf:type gwsw:Putorientatie ;
+
+				gwsw:hasAspect
+				[ 
+					rdf:type gwsw:Punt ;
+					geo:asWKT ?wkt ;
+				] ;
+			] .
+		}
+	  }
+	  bind("red" as ?wktColor)
+	}
 }
+


### PR DESCRIPTION
De query op rioleringsgebieden uitgebreid met uitlaten en pompen. 
De GWSW-publicatie op QGISCloud en via WFS als link toegevoegd.
De home-page (index.md) opgewerkt en ook ingekort tot de essentiële boodschappen.